### PR TITLE
feat: add vanilla JS diagnostic tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,50 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Cloudflare Diagnostic</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cloudflare Diagnostic</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="topbar">
+    <h1>Cloudflare Diagnostic</h1>
+    <span id="status" class="status not-connected">Not connected</span>
+  </header>
+  <div class="container">
+    <aside class="sidebar">
+      <input id="search" type="text" placeholder="Search Workers & Pages" aria-label="Search" />
+      <section>
+        <div class="section-header">
+          <h2>Workers</h2>
+          <label><input type="checkbox" id="workers-select-all" /> Select All</label>
+        </div>
+        <ul id="workers-list" class="list"></ul>
+      </section>
+      <section>
+        <div class="section-header">
+          <h2>Pages</h2>
+          <label><input type="checkbox" id="pages-select-all" /> Select All</label>
+        </div>
+        <ul id="pages-list" class="list"></ul>
+      </section>
+    </aside>
+    <main class="main">
+      <div id="token-card" class="card">
+        <label for="token">API Token</label>
+        <input type="password" id="token" aria-label="API Token" />
+        <button id="connect">OK</button>
+      </div>
+      <div class="actions">
+        <button id="generate" disabled>Generate Report</button>
+        <button id="full-report" disabled>Full Report</button>
+      </div>
+      <div id="report"></div>
+    </main>
+  </div>
+  <footer class="footer">
+    Remember to reset your API key by April 4, 2026.
+  </footer>
+  <script src="main.js"></script>
+</body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,158 @@
+let token = '';
+let accountId = '';
+const statusEl = document.getElementById('status');
+const connectBtn = document.getElementById('connect');
+const tokenInput = document.getElementById('token');
+const workersList = document.getElementById('workers-list');
+const pagesList = document.getElementById('pages-list');
+const generateBtn = document.getElementById('generate');
+const fullReportBtn = document.getElementById('full-report');
+const reportEl = document.getElementById('report');
+const searchInput = document.getElementById('search');
+const workersSelectAll = document.getElementById('workers-select-all');
+const pagesSelectAll = document.getElementById('pages-select-all');
+
+let workers = [];
+let pages = [];
+let selectedWorkers = new Set();
+let selectedPages = new Set();
+
+async function connect() {
+  token = tokenInput.value.trim();
+  if (!token) return;
+  try {
+    const res = await fetch('https://api.cloudflare.com/client/v4/accounts', {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.errors?.[0]?.message || 'Failed to connect');
+    const accs = data.result;
+    if (!accs || accs.length === 0) throw new Error('No accounts found');
+    accountId = accs[0].id;
+    statusEl.textContent = 'Connected';
+    statusEl.classList.remove('not-connected');
+    statusEl.classList.add('connected');
+    await Promise.all([loadWorkers(), loadPages()]);
+    fullReportBtn.disabled = false;
+  } catch (err) {
+    alert(err.message);
+    statusEl.textContent = 'Not connected';
+    statusEl.classList.remove('connected');
+    statusEl.classList.add('not-connected');
+  }
+}
+
+async function cfFetch(path) {
+  const res = await fetch(`https://api.cloudflare.com/client/v4${path}`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.errors?.[0]?.message || res.statusText);
+  return data.result;
+}
+
+async function loadWorkers() {
+  try {
+    workers = await cfFetch(`/accounts/${accountId}/workers/scripts`);
+    renderList(workersList, workers, selectedWorkers, 'name');
+  } catch (e) {
+    console.error('workers', e);
+  }
+}
+
+async function loadPages() {
+  try {
+    pages = await cfFetch(`/accounts/${accountId}/pages/projects`);
+    renderList(pagesList, pages, selectedPages, 'name');
+  } catch (e) {
+    console.error('pages', e);
+  }
+}
+
+function renderList(container, items, selectedSet, key) {
+  container.innerHTML = '';
+  items.forEach(item => {
+    const li = document.createElement('li');
+    const label = document.createElement('label');
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.value = item[key];
+    cb.addEventListener('change', () => {
+      if (cb.checked) selectedSet.add(cb.value); else selectedSet.delete(cb.value);
+      updateGenerateState();
+    });
+    label.appendChild(cb);
+    label.append(' ', item[key]);
+    li.appendChild(label);
+    container.appendChild(li);
+  });
+}
+
+function updateGenerateState() {
+  generateBtn.disabled = !(token && (selectedWorkers.size > 0 || selectedPages.size > 0));
+}
+
+generateBtn.addEventListener('click', async () => {
+  reportEl.textContent = 'Loading...';
+  const workerDetails = [];
+  const pageDetails = [];
+  for (const name of selectedWorkers) {
+    try {
+      const detail = await cfFetch(`/accounts/${accountId}/workers/scripts/${name}`);
+      workerDetails.push(detail);
+    } catch (e) {
+      workerDetails.push({ name, error: e.message });
+    }
+  }
+  for (const name of selectedPages) {
+    try {
+      const detail = await cfFetch(`/accounts/${accountId}/pages/projects/${name}`);
+      pageDetails.push(detail);
+    } catch (e) {
+      pageDetails.push({ name, error: e.message });
+    }
+  }
+  const report = { generatedAt: new Date().toISOString(), workers: workerDetails, pages: pageDetails };
+  reportEl.innerHTML = '<pre>' + JSON.stringify(report, null, 2) + '</pre>';
+});
+
+fullReportBtn.addEventListener('click', async () => {
+  if (!accountId) return;
+  reportEl.textContent = 'Verifying token...';
+  try {
+    const result = await cfFetch(`/accounts/${accountId}/tokens/verify`);
+    reportEl.innerHTML = '<pre>' + JSON.stringify(result, null, 2) + '</pre>';
+  } catch (e) {
+    reportEl.textContent = e.message;
+  }
+});
+
+connectBtn.addEventListener('click', connect);
+
+tokenInput.addEventListener('input', updateGenerateState);
+
+workersSelectAll.addEventListener('change', () => {
+  workersList.querySelectorAll('input[type=checkbox]').forEach(cb => {
+    cb.checked = workersSelectAll.checked;
+    cb.dispatchEvent(new Event('change'));
+  });
+});
+
+pagesSelectAll.addEventListener('change', () => {
+  pagesList.querySelectorAll('input[type=checkbox]').forEach(cb => {
+    cb.checked = pagesSelectAll.checked;
+    cb.dispatchEvent(new Event('change'));
+  });
+});
+
+searchInput.addEventListener('input', () => {
+  const q = searchInput.value.toLowerCase();
+  filterList(workersList, q);
+  filterList(pagesList, q);
+});
+
+function filterList(container, q) {
+  container.querySelectorAll('li').forEach(li => {
+    li.style.display = li.textContent.toLowerCase().includes(q) ? '' : 'none';
+  });
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,78 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background: #f0f0f0;
+}
+.status {
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+.status.not-connected {
+  background: #fdd;
+  color: #900;
+}
+.status.connected {
+  background: #dfd;
+  color: #090;
+}
+.container {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+.sidebar {
+  width: 250px;
+  border-right: 1px solid #ccc;
+  padding: 0.5rem;
+  overflow-y: auto;
+}
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.list li {
+  margin: 0.25rem 0;
+}
+.main {
+  flex: 1;
+  padding: 1rem;
+  overflow-y: auto;
+}
+.card {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+#report pre {
+  background: #f6f8fa;
+  padding: 1rem;
+  overflow: auto;
+}
+.footer {
+  text-align: center;
+  padding: 0.5rem;
+  background: #f0f0f0;
+  font-size: 0.8rem;
+}


### PR DESCRIPTION
## Summary
- replace React entry with simple HTML/CSS layout
- add client-side token verification, workers/pages listing and report generation
- include footer reminder to reset API key by 4 Apr 2026

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689db469ef408321b16d710e73e2ee54