### PR TITLE
Handle account-scoped Cloudflare API tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple static page for generating diagnostic reports for Cloudflare Workers an
 ## Usage
 
 1. Open `index.html` in any modern browser or deploy the repository to a static host such as Cloudflare Pages.
-2. Enter a Cloudflare API token with permissions to read Workers and Pages.
+2. Enter a Cloudflare API token with permissions to read Workers and Pages. Tokens scoped to a single account are supported.
 3. Select the resources to inspect and click **Generate Report** to view the details.
 4. Use **Full Report** to verify the token information.
 


### PR DESCRIPTION
## Summary
- Derive account ID by verifying the API token instead of listing accounts
- Improve API helper to surface Cloudflare errors
- Document support for single-account tokens

## Testing
- `node --check main.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dbf22951083218f4f35552e38df5d